### PR TITLE
Change processing of group taxonomies to 5 posts per task, delete "dt_connection_groups_pushing" meta immediately after post received, remove ordering

### DIFF
--- a/integrations/groups-taxonomy.php
+++ b/integrations/groups-taxonomy.php
@@ -92,7 +92,7 @@ function dt_push_groups() {
 		$found_posts = $query->found_posts;
 
 		if ( $post ) {
-			$post_ids[] = $post->ID;
+			$post_ids[]     = $post->ID;
 			$groups_pushing = get_post_meta( $post->ID, 'dt_connection_groups_pushing', true );
 			delete_post_meta( $post->ID, 'dt_connection_groups_pushing' );
 
@@ -110,23 +110,23 @@ function dt_push_groups() {
 
 			foreach ( $groups_pushing as $key => $group ) {
 				$push_connections = \DT\NbAddon\GroupsTaxonomy\Hooks\get_connections( $group );
-				unset( $groups_pushing[ $key ] );
 
-				if ( empty( $push_connections ) ) {
+				if ( ! empty( $push_connections )) {
+					$connection_map = get_post_meta( $post->ID, 'dt_connection_map', true );
+
+					foreach ( $push_connections as $con ) {
+						if ( empty( $connection_map ) || ! isset( $connection_map['external'] ) || ! in_array( $con['id'], array_keys( $connection_map['external'] ) ) ) { //phpcs:ignore
+							\DT\NbAddon\GroupsTaxonomy\Hooks\push_connection( $con, $post );
+						}
+					}
+
 					if ( ! in_array( $group, $succeeded_groups, true ) ) {
 						$succeeded_groups[] = $group;
 						update_post_meta( $post->ID, 'dt_connection_groups_pushed', $succeeded_groups );
 					}
-					continue;
 				}
 
-				$pushed_connections_map = get_post_meta( $post->ID, 'dt_connection_map', true );
-
-				foreach ( $push_connections as $con ) {
-					if ( empty( $pushed_connections_map ) || ! isset( $pushed_connections_map['external'] ) || ! in_array( $con['id'], array_keys( $pushed_connections_map['external'] ) ) ) { //phpcs:ignore
-						\DT\NbAddon\GroupsTaxonomy\Hooks\push_connection( $con, $post );
-					}
-				}
+				unset( $groups_pushing[ $key ] );
 
 				if ( ! in_array( $group, $succeeded_groups, true ) ) {
 					$succeeded_groups[] = $group;

--- a/integrations/groups-taxonomy.php
+++ b/integrations/groups-taxonomy.php
@@ -102,10 +102,11 @@ function dt_push_groups() {
 				$groups_pushing = array( $groups_pushing );
 			}
 
-			$succeeded_groups = get_post_meta( $post->ID, 'dt_connection_groups_pushed', true );
+			$groups_pushed    = get_post_meta( $post->ID, 'dt_connection_groups_pushed', true );
+			$succeeded_groups = array();
 
-			if ( empty( $successed_groups ) || null === $succeeded_groups ) {
-				$succeeded_groups = array();
+			if ( empty( $groups_pushed ) ) {
+				$groups_pushed = array();
 			}
 
 			foreach ( $groups_pushing as $key => $group ) {
@@ -119,19 +120,15 @@ function dt_push_groups() {
 							\DT\NbAddon\GroupsTaxonomy\Hooks\push_connection( $con, $post );
 						}
 					}
-
-					if ( ! in_array( $group, $succeeded_groups, true ) ) {
-						$succeeded_groups[] = $group;
-						update_post_meta( $post->ID, 'dt_connection_groups_pushed', $succeeded_groups );
-					}
 				}
 
 				unset( $groups_pushing[ $key ] );
+				$succeeded_groups[] = $group;
+			}
 
-				if ( ! in_array( $group, $succeeded_groups, true ) ) {
-					$succeeded_groups[] = $group;
-					update_post_meta( $post->ID, 'dt_connection_groups_pushed', $succeeded_groups );
-				}
+			if ( $added_groups = array_diff( $succeeded_groups,  $groups_pushed ) ) {
+				$groups_pushed = array_merge($groups_pushed, $added_groups);
+				update_post_meta( $post->ID, 'dt_connection_groups_pushed', $groups_pushed );
 			}
 
 			if ( ! empty( $groups_pushing ) ) {

--- a/integrations/groups-taxonomy.php
+++ b/integrations/groups-taxonomy.php
@@ -93,21 +93,15 @@ function dt_push_groups() {
 
 		if ( $post ) {
 			$post_ids[]     = $post->ID;
-			$groups_pushing = get_post_meta( $post->ID, 'dt_connection_groups_pushing', true );
+			$groups_pushing = get_post_meta( $post->ID, 'dt_connection_groups_pushing', true ) ?: array();
 			delete_post_meta( $post->ID, 'dt_connection_groups_pushing' );
 
 			if ( empty( $groups_pushing ) ) {
 				continue;
-			} elseif ( ! is_array( $groups_pushing ) ) {
-				$groups_pushing = array( $groups_pushing );
 			}
 
-			$groups_pushed    = get_post_meta( $post->ID, 'dt_connection_groups_pushed', true );
+			$groups_pushed    = get_post_meta( $post->ID, 'dt_connection_groups_pushed', true ) ?: array();
 			$succeeded_groups = array();
-
-			if ( empty( $groups_pushed ) ) {
-				$groups_pushed = array();
-			}
 
 			foreach ( $groups_pushing as $key => $group ) {
 				$push_connections = \DT\NbAddon\GroupsTaxonomy\Hooks\get_connections( $group );
@@ -127,7 +121,7 @@ function dt_push_groups() {
 			}
 
 			if ( $added_groups = array_diff( $succeeded_groups,  $groups_pushed ) ) {
-				$groups_pushed = array_merge($groups_pushed, $added_groups);
+				$groups_pushed = array_merge( $groups_pushed, $added_groups );
 				update_post_meta( $post->ID, 'dt_connection_groups_pushed', $groups_pushed );
 			}
 

--- a/integrations/groups-taxonomy.php
+++ b/integrations/groups-taxonomy.php
@@ -110,14 +110,12 @@ function dt_push_groups() {
 
 			foreach ( $groups_pushing as $key => $group ) {
 				$push_connections = \DT\NbAddon\GroupsTaxonomy\Hooks\get_connections( $group );
+				unset( $groups_pushing[ $key ] );
 
 				if ( empty( $push_connections ) ) {
 					if ( ! in_array( $group, $succeeded_groups, true ) ) {
 						$succeeded_groups[] = $group;
 						update_post_meta( $post->ID, 'dt_connection_groups_pushed', $succeeded_groups );
-					}
-					if ( false !== $key || null !== $key ) {
-						unset( $groups_pushing[ $key ] );
 					}
 					continue;
 				}
@@ -125,7 +123,7 @@ function dt_push_groups() {
 				$pushed_connections_map = get_post_meta( $post->ID, 'dt_connection_map', true );
 
 				foreach ( $push_connections as $con ) {
-					if ( empty( $pushed_connections_map ) || ! isset( $pushed_connections_map['external'] ) || ! in_array($con['id'], array_keys( $pushed_connections_map['external'] ) ) ) { //phpcs:ignore
+					if ( empty( $pushed_connections_map ) || ! isset( $pushed_connections_map['external'] ) || ! in_array( $con['id'], array_keys( $pushed_connections_map['external'] ) ) ) { //phpcs:ignore
 						\DT\NbAddon\GroupsTaxonomy\Hooks\push_connection( $con, $post );
 					}
 				}
@@ -133,9 +131,6 @@ function dt_push_groups() {
 				if ( ! in_array( $group, $succeeded_groups, true ) ) {
 					$succeeded_groups[] = $group;
 					update_post_meta( $post->ID, 'dt_connection_groups_pushed', $succeeded_groups );
-				}
-				if ( false !== $key || null !== $key ) {
-					unset( $groups_pushing[ $key ] );
 				}
 			}
 
@@ -148,7 +143,7 @@ function dt_push_groups() {
 	}
 
 	// Re-schedule a new event when there are still others to be distributed.
-	if ( $found_posts > 5 ) {
+	if ( $found_posts > 1 ) {
 		schedule_next_pack();
 	}
 

--- a/integrations/groups-taxonomy.php
+++ b/integrations/groups-taxonomy.php
@@ -91,7 +91,7 @@ function dt_push_groups() {
 		$post        = $query->post;
 		$found_posts = $query->found_posts;
 
-		if ( $post instanceof \WP_Post ) {
+		if ( $post ) {
 			$post_ids[] = $post->ID;
 			$groups_pushing = get_post_meta( $post->ID, 'dt_connection_groups_pushing', true );
 			delete_post_meta( $post->ID, 'dt_connection_groups_pushing' );


### PR DESCRIPTION
Change processing of group taxonomies to 5 posts per task, delete "dt_connection_groups_pushing" meta immediately after post received, remove ordering