### PR TITLE
Schedule tasks with 5 priority by default, with 15 priority on REST API calls

### DIFF
--- a/integrations/distributor.php
+++ b/integrations/distributor.php
@@ -34,7 +34,11 @@ function setup() {
  *
  * @return bool
  */
-function schedule_send_notifications( $allow_send_notifications, $post_id, $priority = 15 ) {
+function schedule_send_notifications( $allow_send_notifications, $post_id, $priority = 5 ) {
+	if ( defined('REST_REQUEST') && REST_REQUEST ) {
+		$priority = 15;
+	}
+
 	if ( \DT\NbAddon\DTInBackground\Helpers\is_btm_active() ) {
 		$btm_task     = new \BTM_Task( 'send_notification_in_bg', [], 1, $priority );
 		$btm_bulk_arg = new \BTM_Task_Bulk_Argument( [ $post_id ], -10 );


### PR DESCRIPTION
Schedule tasks with 5 priority by default, with 15 priority on REST API calls